### PR TITLE
Fix/format and lint commands

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = .git,__pycache__,build,dist,venv,infrastructure/cdk.out

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 120
+max-line-length = 140
 exclude = .git,__pycache__,build,dist,venv,infrastructure/cdk.out

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 160
-exclude = .git,__pycache__,build,dist,venv,infrastructure/cdk.out
+exclude = .git,__pycache__,build,dist,venv

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 140
+max-line-length = 160
 exclude = .git,__pycache__,build,dist,venv,infrastructure/cdk.out

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+profile=black
+multi_line_output=8
+src_paths=./**,app/**,infrastructure/**
+skip=venv

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 profile=black
 multi_line_output=8
-src_paths=./**,app/**,infrastructure/**
+src_paths=./**,src/**
 skip=venv


### PR DESCRIPTION
🎩 What? Why?
- Added missing configuration files for `make format` and `make lint` commands
